### PR TITLE
[ADMIN] Visualização e edição dos calendários dos professores

### DIFF
--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/AdminDashBoardController.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/AdminDashBoardController.java
@@ -11,6 +11,11 @@ import javafx.scene.control.*;
 import javafx.scene.text.Text;
 
 import java.io.IOException;
+import br.edu.ifpb.esperanca.eduflow.domain.entities.Aula;
+import br.edu.ifpb.esperanca.eduflow.service.AulaService;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 public class AdminDashBoardController {
@@ -42,6 +47,26 @@ public class AdminDashBoardController {
     @FXML private Text errorUsuario;
     @FXML private Text successUsuario;
 
+    // --- Aba Calendários ---
+    @FXML private ComboBox<Usuario> comboProfessor;
+    @FXML private TableView<Aula> tabelaAulas;
+    @FXML private TableColumn<Aula, String> colAulaProfessor;
+    @FXML private TableColumn<Aula, String> colAulaData;
+    @FXML private TableColumn<Aula, String> colAulaDisciplina;
+    @FXML private TableColumn<Aula, String> colAulaTipo;
+    @FXML private TableColumn<Aula, String> colAulaJustificativa;
+    @FXML private TextField txtAulaData;
+    @FXML private ComboBox<String> comboTipoAula;
+    @FXML private ComboBox<Disciplina> comboDisciplinaAula;
+    @FXML private TextField txtJustificativa;
+    @FXML private Text errorCalendario;
+    @FXML private Text successCalendario;
+
+    @FXML private TabPane tabPane;
+
+    private final AulaService aulaService = new AulaService();
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+
     private final DisciplinaService disciplinaService = new DisciplinaService();
     private final UsuarioService usuarioService = new UsuarioService();
 
@@ -57,6 +82,10 @@ public class AdminDashBoardController {
         configurarFiltros();
         carregarUsuarios();
 
+        configurarTabelaAulas();
+        configurarFormularioAula();
+        handleVerTodasAulas();
+
         // Atualiza o botão quando selecionar um usuário
         tabelaUsuarios.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
             if (selected != null) {
@@ -64,6 +93,14 @@ public class AdminDashBoardController {
                 btnToggleStatus.setStyle(selected.isAtivo()
                         ? "-fx-background-color: #E67E22; -fx-text-fill: white; -fx-background-radius: 5;"
                         : "-fx-background-color: #27AE60; -fx-text-fill: white; -fx-background-radius: 5;");
+            }
+        });
+
+        // Recarrega disciplinas do combo do calendário ao trocar de aba
+        tabPane.getSelectionModel().selectedIndexProperty().addListener((obs, oldIndex, newIndex) -> {
+            if (newIndex.intValue() == 2) { // índice 2 = aba Calendários
+                List<Disciplina> disciplinas = disciplinaService.listarTodas();
+                comboDisciplinaAula.setItems(FXCollections.observableArrayList(disciplinas));
             }
         });
     }
@@ -185,6 +222,151 @@ public class AdminDashBoardController {
         handleFiltrarUsuarios();
     }
 
+    // ===================== CALENDÁRIOS =====================
+
+    private void configurarTabelaAulas() {
+        colAulaProfessor.setCellValueFactory(c ->
+                new SimpleStringProperty(c.getValue().getProfessorNome() != null
+                        ? c.getValue().getProfessorNome() : "—"));
+        colAulaData.setCellValueFactory(c ->
+                new SimpleStringProperty(c.getValue().getDataHora() != null
+                        ? c.getValue().getDataHora().format(FMT) : "—"));
+        colAulaDisciplina.setCellValueFactory(c ->
+                new SimpleStringProperty(c.getValue().getDisciplinaNome() != null
+                        ? c.getValue().getDisciplinaNome() : "—"));
+        colAulaTipo.setCellValueFactory(c ->
+                new SimpleStringProperty(c.getValue().getTipo()));
+        colAulaJustificativa.setCellValueFactory(c ->
+                new SimpleStringProperty(c.getValue().getJustificativa() != null
+                        ? c.getValue().getJustificativa() : ""));
+
+        // Ao selecionar uma aula, preenche o formulário para edição
+        tabelaAulas.getSelectionModel().selectedItemProperty().addListener((obs, old, aula) -> {
+            if (aula != null) {
+                txtAulaData.setText(aula.getDataHora().format(FMT));
+                comboTipoAula.setValue(aula.getTipo());
+                txtJustificativa.setText(aula.getJustificativa() != null ? aula.getJustificativa() : "");
+                // Seleciona a disciplina correspondente no combo
+                comboDisciplinaAula.getItems().stream()
+                        .filter(d -> d.getId().equals(aula.getDisciplinaId()))
+                        .findFirst()
+                        .ifPresent(comboDisciplinaAula::setValue);
+            }
+        });
+    }
+
+    private void configurarFormularioAula() {
+        comboTipoAula.setItems(FXCollections.observableArrayList("REGULAR", "REPOSICAO", "EXTRA"));
+        comboTipoAula.setValue("REGULAR");
+
+        // Carrega professores no combo
+        List<Usuario> professores = usuarioService.listarProfessores();
+        comboProfessor.setItems(FXCollections.observableArrayList(professores));
+        comboProfessor.setConverter(new javafx.util.StringConverter<>() {
+            public String toString(Usuario u) { return u != null ? u.getNome() : ""; }
+            public Usuario fromString(String s) { return null; }
+        });
+
+        // Carrega disciplinas no combo do formulário
+        List<Disciplina> disciplinas = disciplinaService.listarTodas();
+        comboDisciplinaAula.setItems(FXCollections.observableArrayList(disciplinas));
+        comboDisciplinaAula.setConverter(new javafx.util.StringConverter<>() {
+            public String toString(Disciplina d) { return d != null ? d.getNome() : ""; }
+            public Disciplina fromString(String s) { return null; }
+        });
+    }
+
+    @FXML
+    public void handleCarregarCalendario() {
+        Usuario professor = comboProfessor.getValue();
+        if (professor == null) { showErrorCalendario("Selecione um professor."); return; }
+        List<Aula> aulas = aulaService.listarPorProfessor(professor.getId());
+        // Preenche o nome do professor em cada aula para exibição
+        aulas.forEach(a -> a.setProfessorNome(professor.getNome()));
+        tabelaAulas.setItems(FXCollections.observableArrayList(aulas));
+        showSuccessCalendario(aulas.size() + " aula(s) encontrada(s).");
+    }
+
+    @FXML
+    public void handleVerTodasAulas() {
+        List<Aula> aulas = aulaService.listarTodas();
+        tabelaAulas.setItems(FXCollections.observableArrayList(aulas));
+    }
+
+    @FXML
+    public void handleAdicionarAula() {
+        try {
+            Aula aula = coletarFormulario(null);
+            aulaService.cadastrar(aula);
+            showSuccessCalendario("Aula adicionada com sucesso.");
+            handleVerTodasAulas();
+            limparFormularioAula();
+        } catch (Exception e) {
+            showErrorCalendario(e.getMessage());
+        }
+    }
+
+    @FXML
+    public void handleEditarAula() {
+        Aula selecionada = tabelaAulas.getSelectionModel().getSelectedItem();
+        if (selecionada == null) { showErrorCalendario("Selecione uma aula para editar."); return; }
+        try {
+            Aula aula = coletarFormulario(selecionada.getId());
+            aulaService.editar(aula);
+            showSuccessCalendario("Aula atualizada com sucesso.");
+            handleVerTodasAulas();
+            limparFormularioAula();
+        } catch (Exception e) {
+            showErrorCalendario(e.getMessage());
+        }
+    }
+
+    @FXML
+    public void handleRemoverAula() {
+        Aula selecionada = tabelaAulas.getSelectionModel().getSelectedItem();
+        if (selecionada == null) { showErrorCalendario("Selecione uma aula para remover."); return; }
+        aulaService.excluir(selecionada.getId());
+        showSuccessCalendario("Aula removida.");
+        handleVerTodasAulas();
+        limparFormularioAula();
+    }
+
+    @FXML
+    public void handleLimparSelecaoAula() {
+        tabelaAulas.getSelectionModel().clearSelection();
+        limparFormularioAula();
+    }
+
+    private Aula coletarFormulario(Long id) {
+        String dataStr = txtAulaData.getText().trim();
+        String tipo = comboTipoAula.getValue();
+        Disciplina disciplina = comboDisciplinaAula.getValue();
+        Usuario professor = comboProfessor.getValue();
+        String justificativa = txtJustificativa.getText().trim();
+
+        if (dataStr.isEmpty()) throw new RuntimeException("Informe a data e hora da aula.");
+        if (professor == null) throw new RuntimeException("Selecione o professor.");
+        if (disciplina == null) throw new RuntimeException("Selecione a disciplina.");
+
+        LocalDateTime dataHora;
+        try {
+            dataHora = LocalDateTime.parse(dataStr, FMT);
+        } catch (DateTimeParseException e) {
+            throw new RuntimeException("Data inválida. Use o formato dd/MM/yyyy HH:mm.");
+        }
+
+        Aula aula = new Aula(id, dataHora, tipo, justificativa.isEmpty() ? null : justificativa,
+                professor.getId(), disciplina.getId());
+        return aula;
+    }
+
+    private void limparFormularioAula() {
+        txtAulaData.clear();
+        txtJustificativa.clear();
+        comboTipoAula.setValue("REGULAR");
+        comboDisciplinaAula.setValue(null);
+    }
+
     // ===================== LOGOUT =====================
 
     @FXML
@@ -209,4 +391,13 @@ public class AdminDashBoardController {
         if (successUsuario != null) { successUsuario.setText(msg); successUsuario.setVisible(true); }
         if (errorUsuario != null) errorUsuario.setVisible(false);
     }
+    private void showErrorCalendario(String msg) {
+        if (errorCalendario != null) { errorCalendario.setText(msg); errorCalendario.setVisible(true); }
+        if (successCalendario != null) successCalendario.setVisible(false);
+    }
+    private void showSuccessCalendario(String msg) {
+        if (successCalendario != null) { successCalendario.setText(msg); successCalendario.setVisible(true); }
+        if (errorCalendario != null) errorCalendario.setVisible(false);
+    }
 }
+

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/domain/entities/Aula.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/domain/entities/Aula.java
@@ -1,0 +1,48 @@
+package br.edu.ifpb.esperanca.eduflow.domain.entities;
+
+import java.time.LocalDateTime;
+
+/**
+ * Representa uma aula no calendário de um professor.
+ * Tipos: REGULAR, REPOSICAO, EXTRA
+ */
+public class Aula {
+
+    private Long id;
+    private LocalDateTime dataHora;
+    private String tipo; // REGULAR, REPOSICAO, EXTRA
+    private String justificativa;
+    private Long professorId;
+    private String professorNome;
+    private Long disciplinaId;
+    private String disciplinaNome;
+
+    public Aula() {}
+
+    public Aula(Long id, LocalDateTime dataHora, String tipo, String justificativa,
+                Long professorId, Long disciplinaId) {
+        this.id = id;
+        this.dataHora = dataHora;
+        this.tipo = tipo;
+        this.justificativa = justificativa;
+        this.professorId = professorId;
+        this.disciplinaId = disciplinaId;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public LocalDateTime getDataHora() { return dataHora; }
+    public void setDataHora(LocalDateTime dataHora) { this.dataHora = dataHora; }
+    public String getTipo() { return tipo; }
+    public void setTipo(String tipo) { this.tipo = tipo; }
+    public String getJustificativa() { return justificativa; }
+    public void setJustificativa(String justificativa) { this.justificativa = justificativa; }
+    public Long getProfessorId() { return professorId; }
+    public void setProfessorId(Long professorId) { this.professorId = professorId; }
+    public String getProfessorNome() { return professorNome; }
+    public void setProfessorNome(String professorNome) { this.professorNome = professorNome; }
+    public Long getDisciplinaId() { return disciplinaId; }
+    public void setDisciplinaId(Long disciplinaId) { this.disciplinaId = disciplinaId; }
+    public String getDisciplinaNome() { return disciplinaNome; }
+    public void setDisciplinaNome(String disciplinaNome) { this.disciplinaNome = disciplinaNome; }
+}

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/AulaRepository.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/AulaRepository.java
@@ -1,0 +1,116 @@
+package br.edu.ifpb.esperanca.eduflow.repository;
+
+import br.edu.ifpb.esperanca.eduflow.domain.entities.Aula;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AulaRepository {
+
+    private Connection conn() {
+        return ConectionFactory.getConnection();
+    }
+
+    public Aula salvar(Aula aula) {
+        String sql = """
+            INSERT INTO aulas (data_hora, tipo, justificativa, professor_id, disciplina_id)
+            VALUES (?, ?, ?, ?, ?)
+            """;
+        try (PreparedStatement stmt = conn().prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(aula.getDataHora()));
+            stmt.setString(2, aula.getTipo());
+            stmt.setString(3, aula.getJustificativa());
+            stmt.setLong(4, aula.getProfessorId());
+            stmt.setLong(5, aula.getDisciplinaId());
+            stmt.executeUpdate();
+            ResultSet rs = stmt.getGeneratedKeys();
+            if (rs.next()) aula.setId(rs.getLong(1));
+            return aula;
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao salvar aula: " + e.getMessage(), e);
+        }
+    }
+
+    public void atualizar(Aula aula) {
+        String sql = """
+            UPDATE aulas SET data_hora = ?, tipo = ?, justificativa = ?, disciplina_id = ?
+            WHERE id = ?
+            """;
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(aula.getDataHora()));
+            stmt.setString(2, aula.getTipo());
+            stmt.setString(3, aula.getJustificativa());
+            stmt.setLong(4, aula.getDisciplinaId());
+            stmt.setLong(5, aula.getId());
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao atualizar aula: " + e.getMessage(), e);
+        }
+    }
+
+    public void excluir(Long id) {
+        String sql = "DELETE FROM aulas WHERE id = ?";
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao excluir aula: " + e.getMessage(), e);
+        }
+    }
+
+    /** Lista aulas de um professor específico, com nome da disciplina. */
+    public List<Aula> listarPorProfessor(Long professorId) {
+        String sql = """
+            SELECT a.*, d.nome AS disciplina_nome
+            FROM aulas a
+            JOIN disciplinas d ON d.id = a.disciplina_id
+            WHERE a.professor_id = ?
+            ORDER BY a.data_hora
+            """;
+        List<Aula> lista = new ArrayList<>();
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, professorId);
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) lista.add(mapear(rs));
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar aulas: " + e.getMessage(), e);
+        }
+        return lista;
+    }
+
+    /** Lista todas as aulas de todos os professores (visão admin). */
+    public List<Aula> listarTodas() {
+        String sql = """
+            SELECT a.*, d.nome AS disciplina_nome, u.nome AS professor_nome
+            FROM aulas a
+            JOIN disciplinas d ON d.id = a.disciplina_id
+            JOIN usuarios u ON u.id = a.professor_id
+            ORDER BY a.data_hora
+            """;
+        List<Aula> lista = new ArrayList<>();
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                Aula au = mapear(rs);
+                au.setProfessorNome(rs.getString("professor_nome"));
+                lista.add(au);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar aulas: " + e.getMessage(), e);
+        }
+        return lista;
+    }
+
+    private Aula mapear(ResultSet rs) throws SQLException {
+        Aula a = new Aula();
+        a.setId(rs.getLong("id"));
+        a.setDataHora(rs.getTimestamp("data_hora").toLocalDateTime());
+        a.setTipo(rs.getString("tipo"));
+        a.setJustificativa(rs.getString("justificativa"));
+        a.setProfessorId(rs.getLong("professor_id"));
+        a.setDisciplinaId(rs.getLong("disciplina_id"));
+        a.setDisciplinaNome(rs.getString("disciplina_nome"));
+        return a;
+    }
+}

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/UsuarioRepository.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/UsuarioRepository.java
@@ -118,6 +118,18 @@ public class UsuarioRepository {
         return Optional.empty();
     }
 
+    public List<Usuario> listarProfessores() {
+        String sql = "SELECT * FROM usuarios WHERE role = 'PROFESSOR' AND ativo = TRUE ORDER BY nome";
+        List<Usuario> lista = new ArrayList<>();
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) lista.add(mapearUsuario(rs));
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar professores: " + e.getMessage(), e);
+        }
+        return lista;
+    }
+
     public void atualizar(Usuario usuario) {
         String sql = "UPDATE usuarios SET nome = ?, email = ? WHERE id = ?";
         try (PreparedStatement stmt = conn().prepareStatement(sql)) {

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/service/AulaService.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/service/AulaService.java
@@ -1,0 +1,46 @@
+package br.edu.ifpb.esperanca.eduflow.service;
+
+import br.edu.ifpb.esperanca.eduflow.domain.entities.Aula;
+import br.edu.ifpb.esperanca.eduflow.domain.exceptions.BusinessException;
+import br.edu.ifpb.esperanca.eduflow.repository.AulaRepository;
+
+import java.util.List;
+
+public class AulaService {
+
+    private final AulaRepository aulaRepository = new AulaRepository();
+
+    public Aula cadastrar(Aula aula) {
+        validar(aula);
+        return aulaRepository.salvar(aula);
+    }
+
+    public void editar(Aula aula) {
+        if (aula.getId() == null) throw new BusinessException("Aula sem ID para edição.");
+        validar(aula);
+        aulaRepository.atualizar(aula);
+    }
+
+    public void excluir(Long id) {
+        aulaRepository.excluir(id);
+    }
+
+    public List<Aula> listarPorProfessor(Long professorId) {
+        return aulaRepository.listarPorProfessor(professorId);
+    }
+
+    public List<Aula> listarTodas() {
+        return aulaRepository.listarTodas();
+    }
+
+    private void validar(Aula aula) {
+        if (aula.getDataHora() == null)
+            throw new BusinessException("Data e hora da aula são obrigatórios.");
+        if (aula.getTipo() == null || aula.getTipo().isBlank())
+            throw new BusinessException("Tipo da aula é obrigatório.");
+        if (aula.getProfessorId() == null)
+            throw new BusinessException("Professor é obrigatório.");
+        if (aula.getDisciplinaId() == null)
+            throw new BusinessException("Disciplina é obrigatória.");
+    }
+}

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/service/UsuarioService.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/service/UsuarioService.java
@@ -54,6 +54,10 @@ public class UsuarioService {
         usuarioRepository.alterarRole(usuario.getId(), novoRole);
     }
 
+    public List<Usuario> listarProfessores() {
+        return usuarioRepository.listarProfessores();
+    }
+
     public void alterarStatus(Usuario usuario, boolean ativo) {
         usuarioRepository.alterarStatus(usuario.getId(), ativo);
     }

--- a/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/admin_dashboard.fxml
+++ b/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/admin_dashboard.fxml
@@ -16,7 +16,7 @@
         </HBox>
     </top>
     <center>
-        <TabPane tabClosingPolicy="UNAVAILABLE" style="-fx-padding: 10;">
+        <TabPane fx:id="tabPane" tabClosingPolicy="UNAVAILABLE" style="-fx-padding: 10;">
 
             <!-- ABA 1: Disciplinas -->
             <Tab text="Disciplinas">
@@ -84,6 +84,56 @@
 
                     <Text fx:id="errorUsuario" fill="RED" visible="false"/>
                     <Text fx:id="successUsuario" fill="GREEN" visible="false"/>
+                </VBox>
+            </Tab>
+
+            <!-- ABA 3: Calendários de Professores -->
+            <Tab text="Calendários">
+                <VBox spacing="10" style="-fx-padding: 15;">
+                    <Label text="Calendários de Aula dos Professores" style="-fx-font-size: 15px; -fx-font-weight: bold;"/>
+
+                    <!-- Seleção de professor -->
+                    <HBox spacing="10" alignment="CENTER_LEFT">
+                        <Label text="Professor:"/>
+                        <ComboBox fx:id="comboProfessor" prefWidth="220"/>
+                        <Button text="Ver Calendário" onAction="#handleCarregarCalendario"
+                                style="-fx-background-color: #2980B9; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Ver Todos" onAction="#handleVerTodasAulas"
+                                style="-fx-background-color: #7F8C8D; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                    </HBox>
+
+                    <!-- Tabela de aulas -->
+                    <TableView fx:id="tabelaAulas" VBox.vgrow="ALWAYS" prefHeight="250">
+                        <columns>
+                            <TableColumn fx:id="colAulaProfessor" text="Professor" prefWidth="150"/>
+                            <TableColumn fx:id="colAulaData" text="Data/Hora" prefWidth="150"/>
+                            <TableColumn fx:id="colAulaDisciplina" text="Disciplina" prefWidth="160"/>
+                            <TableColumn fx:id="colAulaTipo" text="Tipo" prefWidth="90"/>
+                            <TableColumn fx:id="colAulaJustificativa" text="Justificativa" prefWidth="220"/>
+                        </columns>
+                    </TableView>
+
+                    <!-- Formulário para adicionar/editar aula -->
+                    <Label text="Adicionar / Editar Aula:" style="-fx-font-weight: bold;"/>
+                    <HBox spacing="8" alignment="CENTER_LEFT">
+                        <TextField fx:id="txtAulaData" promptText="Data (dd/MM/yyyy HH:mm)" prefWidth="175"/>
+                        <ComboBox fx:id="comboTipoAula" prefWidth="120"/>
+                        <ComboBox fx:id="comboDisciplinaAula" prefWidth="180"/>
+                        <TextField fx:id="txtJustificativa" promptText="Justificativa (opcional)" prefWidth="200"/>
+                    </HBox>
+                    <HBox spacing="8" alignment="CENTER_LEFT">
+                        <Button text="Adicionar Aula" onAction="#handleAdicionarAula"
+                                style="-fx-background-color: #27AE60; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Editar Selecionada" onAction="#handleEditarAula"
+                                style="-fx-background-color: #F39C12; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Remover Selecionada" onAction="#handleRemoverAula"
+                                style="-fx-background-color: #E74C3C; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Limpar Seleção" onAction="#handleLimparSelecaoAula"
+                                style="-fx-background-color: #95A5A6; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                    </HBox>
+
+                    <Text fx:id="errorCalendario" fill="RED" visible="false"/>
+                    <Text fx:id="successCalendario" fill="GREEN" visible="false"/>
                 </VBox>
             </Tab>
 


### PR DESCRIPTION
## O que foi feito
Implementação completa da issue #5 — aba de calendários de aula dos professores no dashboard do administrador.

## Mudanças
- **Banco:** criada tabela `aulas` com campos de data, tipo, justificativa, professor e disciplina
- **Domain:** entidade `Aula` já existente utilizada como base
- **Repository:** novo `AulaRepository` com métodos `salvar`, `atualizar`, `excluir`, `listarPorProfessor` e `listarTodas`
- **Service:** novo `AulaService` com validações de negócio
- **UsuarioRepository/Service:** adicionado método `listarProfessores`
- **Controller/FXML:** nova aba "Calendários" no dashboard admin com atualização em tempo real

## Funcionalidades
- [x] Listar todos os professores com seleção por ComboBox
- [x] Visualizar o calendário de aulas de um professor específico ou de todos
- [x] Adicionar aulas ao calendário (tipos: REGULAR, REPOSIÇÃO, EXTRA)
- [x] Editar aula selecionada com preenchimento automático do formulário
- [x] Remover aula selecionada
- [x] Visualizar justificativas cadastradas
- [x] Disciplinas atualizadas em tempo real ao trocar de aba (sem precisar relogar)

## Como testar
1. Rode o SQL:
```sql
CREATE TABLE IF NOT EXISTS aulas (
    id            BIGSERIAL PRIMARY KEY,
    data_hora     TIMESTAMP   NOT NULL,
    tipo          VARCHAR(20) NOT NULL CHECK (tipo IN ('REGULAR','REPOSICAO','EXTRA')),
    justificativa TEXT,
    professor_id  BIGINT NOT NULL REFERENCES usuarios(id),
    disciplina_id BIGINT NOT NULL REFERENCES disciplinas(id)
);
```
2. Faça login como administrador
3. Acesse a aba **Calendários** no dashboard

Closes #5 