### PR TITLE
[PROFESSOR] Vínculo professor ↔ disciplina

### DIFF
--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/AdminDashBoardController.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/AdminDashBoardController.java
@@ -11,6 +11,7 @@ import javafx.scene.control.*;
 import javafx.scene.text.Text;
 
 import java.io.IOException;
+import br.edu.ifpb.esperanca.eduflow.service.ProfessorDisciplinaService;
 import br.edu.ifpb.esperanca.eduflow.domain.entities.Aula;
 import br.edu.ifpb.esperanca.eduflow.service.AulaService;
 import java.time.LocalDateTime;
@@ -64,6 +65,15 @@ public class AdminDashBoardController {
 
     @FXML private TabPane tabPane;
 
+    // --- Aba Usuários: Vínculo Professor ↔ Disciplina ---
+    @FXML private ComboBox<Disciplina> comboDisciplinaVinculo;
+    @FXML private TableView<Disciplina> tabelaDisciplinasProfessor;
+    @FXML private TableColumn<Disciplina, String> colDPNome;
+    @FXML private TableColumn<Disciplina, String> colDPCodigo;
+    @FXML private TableColumn<Disciplina, String> colDPSemestre;
+
+    private final ProfessorDisciplinaService professorDisciplinaService = new ProfessorDisciplinaService();
+
     private final AulaService aulaService = new AulaService();
     private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
@@ -81,6 +91,7 @@ public class AdminDashBoardController {
         configurarTabelaUsuarios();
         configurarFiltros();
         carregarUsuarios();
+        configurarTabelaDisciplinasProfessor();
 
         configurarTabelaAulas();
         configurarFormularioAula();
@@ -220,6 +231,74 @@ public class AdminDashBoardController {
         usuarioService.alterarStatus(selecionado, novoStatus);
         showSuccessUsuario("Conta " + (novoStatus ? "habilitada" : "desabilitada") + " com sucesso.");
         handleFiltrarUsuarios();
+    }
+
+    private void configurarTabelaDisciplinasProfessor() {
+        colDPNome.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getNome()));
+        colDPCodigo.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getCodigo()));
+        colDPSemestre.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getSemestreLetivo()));
+
+        // Preenche o combo de disciplinas para vínculo
+        List<Disciplina> disciplinas = disciplinaService.listarTodas();
+        comboDisciplinaVinculo.setItems(FXCollections.observableArrayList(disciplinas));
+        comboDisciplinaVinculo.setConverter(new javafx.util.StringConverter<>() {
+            public String toString(Disciplina d) { return d != null ? d.getNome() + " (" + d.getCodigo() + ")" : ""; }
+            public Disciplina fromString(String s) { return null; }
+        });
+
+        // Ao selecionar um usuário na tabela, se for professor carrega suas disciplinas automaticamente
+        tabelaUsuarios.getSelectionModel().selectedItemProperty().addListener((obs, old, selected) -> {
+            if (selected != null && selected.getRole().name().equals("PROFESSOR")) {
+                atualizarTabelaDisciplinasProfessor(selected.getId());
+            } else {
+                tabelaDisciplinasProfessor.getItems().clear();
+            }
+        });
+    }
+
+    private void atualizarTabelaDisciplinasProfessor(Long professorId) {
+        List<Disciplina> disciplinas = professorDisciplinaService.listarPorProfessor(professorId);
+        tabelaDisciplinasProfessor.setItems(FXCollections.observableArrayList(disciplinas));
+    }
+
+    @FXML
+    public void handleVincularDisciplina() {
+        Usuario selecionado = tabelaUsuarios.getSelectionModel().getSelectedItem();
+        if (selecionado == null) { showErrorUsuario("Selecione um professor na tabela."); return; }
+        if (!selecionado.getRole().name().equals("PROFESSOR")) { showErrorUsuario("O usuário selecionado não é um professor."); return; }
+        Disciplina disciplina = comboDisciplinaVinculo.getValue();
+        if (disciplina == null) { showErrorUsuario("Selecione uma disciplina."); return; }
+        try {
+            professorDisciplinaService.vincular(selecionado.getId(), disciplina.getId());
+            showSuccessUsuario("Disciplina vinculada ao professor com sucesso.");
+            atualizarTabelaDisciplinasProfessor(selecionado.getId());
+        } catch (Exception e) {
+            showErrorUsuario(e.getMessage());
+        }
+    }
+
+    @FXML
+    public void handleDesvincularDisciplina() {
+        Usuario selecionado = tabelaUsuarios.getSelectionModel().getSelectedItem();
+        if (selecionado == null) { showErrorUsuario("Selecione um professor na tabela."); return; }
+        if (!selecionado.getRole().name().equals("PROFESSOR")) { showErrorUsuario("O usuário selecionado não é um professor."); return; }
+        Disciplina disciplina = comboDisciplinaVinculo.getValue();
+        if (disciplina == null) { showErrorUsuario("Selecione uma disciplina."); return; }
+        try {
+            professorDisciplinaService.desvincular(selecionado.getId(), disciplina.getId());
+            showSuccessUsuario("Disciplina desvinculada do professor.");
+            atualizarTabelaDisciplinasProfessor(selecionado.getId());
+        } catch (Exception e) {
+            showErrorUsuario(e.getMessage());
+        }
+    }
+
+    @FXML
+    public void handleVerDisciplinasProfessor() {
+        Usuario selecionado = tabelaUsuarios.getSelectionModel().getSelectedItem();
+        if (selecionado == null) { showErrorUsuario("Selecione um professor na tabela."); return; }
+        if (!selecionado.getRole().name().equals("PROFESSOR")) { showErrorUsuario("O usuário selecionado não é um professor."); return; }
+        atualizarTabelaDisciplinasProfessor(selecionado.getId());
     }
 
     // ===================== CALENDÁRIOS =====================

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/ProfessorDashboardController.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/controller/ProfessorDashboardController.java
@@ -15,6 +15,15 @@ import java.util.List;
 public class ProfessorDashboardController {
 
     @FXML private Label lblBemVindo;
+
+    // --- Aba Disciplinas ---
+    @FXML private TableView<Disciplina> tabelaDisciplinas;
+    @FXML private TableColumn<Disciplina, String> colDisciplinaNome;
+    @FXML private TableColumn<Disciplina, String> colDisciplinaCodigo;
+    @FXML private TableColumn<Disciplina, String> colDisciplinaSemestre;
+    @FXML private Text msgDisciplinas;
+
+    // --- Aba Validação ---
     @FXML private TableView<Agendamento> tabelaParaValidar;
     @FXML private TableColumn<Agendamento, String> colStatus;
     @FXML private TableColumn<Agendamento, String> colAssunto;
@@ -23,7 +32,7 @@ public class ProfessorDashboardController {
     @FXML private Text successMessage;
 
     private final AgendamentoService agendamentoService = new AgendamentoService();
-    private final DisciplinaService disciplinaService = new DisciplinaService();
+    private final ProfessorDisciplinaService professorDisciplinaService = new ProfessorDisciplinaService();
     private Professor professorLogado;
 
     @FXML
@@ -31,35 +40,50 @@ public class ProfessorDashboardController {
         professorLogado = (Professor) SessionManager.getInstance().getUsuarioLogado();
         lblBemVindo.setText("Prof. " + professorLogado.getNome());
 
-        List<Disciplina> disciplinas = disciplinaService.listarPorProfessor(professorLogado.getId());
-        professorLogado.setDisciplinas(disciplinas);
+        configurarTabelaDisciplinas();
+        carregarDisciplinas();
 
-        configurarTabela();
+        configurarTabelaValidacao();
         carregarAgendamentosParaValidar();
     }
 
-    private void configurarTabela() {
+    // ===================== DISCIPLINAS =====================
+
+    private void configurarTabelaDisciplinas() {
+        colDisciplinaNome.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getNome()));
+        colDisciplinaCodigo.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getCodigo()));
+        colDisciplinaSemestre.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getSemestreLetivo()));
+    }
+
+    private void carregarDisciplinas() {
+        List<Disciplina> disciplinas = professorDisciplinaService.listarPorProfessor(professorLogado.getId());
+        professorLogado.setDisciplinas(disciplinas);
+
+        if (disciplinas.isEmpty()) {
+            if (msgDisciplinas != null) {
+                msgDisciplinas.setText("Nenhuma disciplina vinculada. Solicite ao administrador.");
+                msgDisciplinas.setVisible(true);
+            }
+        }
+        tabelaDisciplinas.setItems(FXCollections.observableArrayList(disciplinas));
+    }
+
+    // ===================== VALIDAÇÃO =====================
+
+    private void configurarTabelaValidacao() {
         if (colStatus != null)
-            colStatus.setCellValueFactory(cell ->
-                    new SimpleStringProperty(cell.getValue().getStatus().name()));
+            colStatus.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getStatus().name()));
         if (colAssunto != null)
-            colAssunto.setCellValueFactory(cell ->
-                    new SimpleStringProperty(cell.getValue().getAssunto()));
+            colAssunto.setCellValueFactory(c -> new SimpleStringProperty(c.getValue().getAssunto()));
         if (colAluno != null)
-            colAluno.setCellValueFactory(cell -> {
-                Aluno aluno = cell.getValue().getAluno();
+            colAluno.setCellValueFactory(c -> {
+                Aluno aluno = c.getValue().getAluno();
                 return new SimpleStringProperty(aluno != null ? aluno.getNome() : "—");
             });
     }
 
     private void carregarAgendamentosParaValidar() {
-        // Carrega todos os agendamentos REALIZADO/FALTOU das agendas dos monitores vinculados
-        // Por ora lista a partir do primeiro monitor da primeira disciplina do professor
         if (tabelaParaValidar == null) return;
-        if (professorLogado.getDisciplinas().isEmpty()) return;
-
-        // Usa primeiro monitor vinculado como pivot (simplificação acadêmica)
-        // Em produção filtraria por todas as disciplinas do professor
         tabelaParaValidar.setItems(FXCollections.observableArrayList(List.of()));
     }
 
@@ -68,14 +92,11 @@ public class ProfessorDashboardController {
         if (tabelaParaValidar == null) return;
         Agendamento selecionado = tabelaParaValidar.getSelectionModel().getSelectedItem();
         if (selecionado == null) { showError("Selecione um agendamento para validar."); return; }
-
         try {
             Agenda agenda = selecionado.getAgenda();
             Disciplina disciplina = agenda != null ? agenda.getDisciplina() : null;
             if (disciplina == null) { showError("Disciplina do agendamento não encontrada."); return; }
-
             professorLogado.validarAtendimento(selecionado, disciplina);
-            agendamentoService.listarParaValidacao(professorLogado.getId()); // atualiza
             showSuccess("Atendimento validado com sucesso! (RN02/RN09)");
             carregarAgendamentosParaValidar();
         } catch (Exception e) {

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/ProfessorDisciplinaRepository.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/repository/ProfessorDisciplinaRepository.java
@@ -1,0 +1,69 @@
+package br.edu.ifpb.esperanca.eduflow.repository;
+
+import br.edu.ifpb.esperanca.eduflow.domain.entities.Disciplina;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProfessorDisciplinaRepository {
+
+    private Connection conn() {
+        return ConectionFactory.getConnection();
+    }
+
+    public void vincular(Long professorId, Long disciplinaId) {
+        String sql = "INSERT INTO professor_disciplina (professor_id, disciplina_id) VALUES (?, ?) ON CONFLICT DO NOTHING";
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, professorId);
+            stmt.setLong(2, disciplinaId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao vincular professor à disciplina: " + e.getMessage(), e);
+        }
+    }
+
+    public void desvincular(Long professorId, Long disciplinaId) {
+        String sql = "DELETE FROM professor_disciplina WHERE professor_id = ? AND disciplina_id = ?";
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, professorId);
+            stmt.setLong(2, disciplinaId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao desvincular professor da disciplina: " + e.getMessage(), e);
+        }
+    }
+
+    public List<Disciplina> listarPorProfessor(Long professorId) {
+        String sql = """
+            SELECT d.* FROM disciplinas d
+            JOIN professor_disciplina pd ON pd.disciplina_id = d.id
+            WHERE pd.professor_id = ?
+            ORDER BY d.nome
+            """;
+        List<Disciplina> lista = new ArrayList<>();
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, professorId);
+            ResultSet rs = stmt.executeQuery();
+            while (rs.next()) lista.add(new Disciplina(
+                    rs.getLong("id"),
+                    rs.getString("nome"),
+                    rs.getString("codigo"),
+                    rs.getString("semestre_letivo")));
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar disciplinas do professor: " + e.getMessage(), e);
+        }
+        return lista;
+    }
+
+    public boolean estaVinculado(Long professorId, Long disciplinaId) {
+        String sql = "SELECT 1 FROM professor_disciplina WHERE professor_id = ? AND disciplina_id = ?";
+        try (PreparedStatement stmt = conn().prepareStatement(sql)) {
+            stmt.setLong(1, professorId);
+            stmt.setLong(2, disciplinaId);
+            return stmt.executeQuery().next();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao verificar vínculo: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/br/edu/ifpb/esperanca/eduflow/service/ProfessorDisciplinaService.java
+++ b/src/main/java/br/edu/ifpb/esperanca/eduflow/service/ProfessorDisciplinaService.java
@@ -1,0 +1,30 @@
+package br.edu.ifpb.esperanca.eduflow.service;
+
+import br.edu.ifpb.esperanca.eduflow.domain.entities.Disciplina;
+import br.edu.ifpb.esperanca.eduflow.domain.exceptions.BusinessException;
+import br.edu.ifpb.esperanca.eduflow.repository.ProfessorDisciplinaRepository;
+
+import java.util.List;
+
+public class ProfessorDisciplinaService {
+
+    private final ProfessorDisciplinaRepository repo = new ProfessorDisciplinaRepository();
+
+    public void vincular(Long professorId, Long disciplinaId) {
+        if (professorId == null || disciplinaId == null)
+            throw new BusinessException("Professor e disciplina são obrigatórios.");
+        if (repo.estaVinculado(professorId, disciplinaId))
+            throw new BusinessException("Professor já está vinculado a esta disciplina.");
+        repo.vincular(professorId, disciplinaId);
+    }
+
+    public void desvincular(Long professorId, Long disciplinaId) {
+        if (!repo.estaVinculado(professorId, disciplinaId))
+            throw new BusinessException("Professor não está vinculado a esta disciplina.");
+        repo.desvincular(professorId, disciplinaId);
+    }
+
+    public List<Disciplina> listarPorProfessor(Long professorId) {
+        return repo.listarPorProfessor(professorId);
+    }
+}

--- a/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/admin_dashboard.fxml
+++ b/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/admin_dashboard.fxml
@@ -82,6 +82,26 @@
                                 style="-fx-background-color: #E67E22; -fx-text-fill: white; -fx-background-radius: 5;"/>
                     </HBox>
 
+                    <!-- Vínculo Professor ↔ Disciplina -->
+                    <Label text="Vínculo Professor ↔ Disciplina:" style="-fx-font-weight: bold; -fx-padding: 8 0 0 0;"/>
+                    <HBox spacing="10" alignment="CENTER_LEFT">
+                        <Label text="Disciplina:"/>
+                        <ComboBox fx:id="comboDisciplinaVinculo" prefWidth="220"/>
+                        <Button text="Vincular" onAction="#handleVincularDisciplina"
+                                style="-fx-background-color: #27AE60; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Desvincular" onAction="#handleDesvincularDisciplina"
+                                style="-fx-background-color: #E74C3C; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                        <Button text="Ver Disciplinas do Professor" onAction="#handleVerDisciplinasProfessor"
+                                style="-fx-background-color: #2980B9; -fx-text-fill: white; -fx-background-radius: 5;"/>
+                    </HBox>
+                    <TableView fx:id="tabelaDisciplinasProfessor" prefHeight="130">
+                        <columns>
+                            <TableColumn fx:id="colDPNome" text="Disciplina" prefWidth="250"/>
+                            <TableColumn fx:id="colDPCodigo" text="Código" prefWidth="120"/>
+                            <TableColumn fx:id="colDPSemestre" text="Semestre" prefWidth="120"/>
+                        </columns>
+                    </TableView>
+
                     <Text fx:id="errorUsuario" fill="RED" visible="false"/>
                     <Text fx:id="successUsuario" fill="GREEN" visible="false"/>
                 </VBox>

--- a/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/professor_dashboard.fxml
+++ b/src/main/resources/br/edu/ifpb/esperanca/eduflow/view/professor_dashboard.fxml
@@ -16,20 +16,42 @@
         </HBox>
     </top>
     <center>
-        <VBox spacing="10" style="-fx-padding: 20;">
-            <Label text="Painel de Validação — Atendimentos para Aprovar (RN02/RN09)"
-                   style="-fx-font-size: 16px; -fx-font-weight: bold;"/>
-            <TableView fx:id="tabelaParaValidar" prefHeight="350" VBox.vgrow="ALWAYS">
-                <columns>
-                    <TableColumn fx:id="colAluno" text="Aluno" prefWidth="200"/>
-                    <TableColumn fx:id="colAssunto" text="Assunto" prefWidth="300"/>
-                    <TableColumn fx:id="colStatus" text="Status" prefWidth="150"/>
-                </columns>
-            </TableView>
-            <Button text="Validar Atendimento Selecionado" onAction="#handleValidar"
-                    style="-fx-background-color: #6C3483; -fx-text-fill: white; -fx-font-size: 14px; -fx-background-radius: 5;"/>
-            <Text fx:id="errorMessage" fill="RED" visible="false"/>
-            <Text fx:id="successMessage" fill="GREEN" visible="false"/>
-        </VBox>
+        <TabPane tabClosingPolicy="UNAVAILABLE" style="-fx-padding: 10;">
+
+            <!-- ABA 1: Minhas Disciplinas -->
+            <Tab text="Minhas Disciplinas">
+                <VBox spacing="10" style="-fx-padding: 15;">
+                    <Label text="Disciplinas Vinculadas" style="-fx-font-size: 15px; -fx-font-weight: bold;"/>
+                    <TableView fx:id="tabelaDisciplinas" VBox.vgrow="ALWAYS" prefHeight="350">
+                        <columns>
+                            <TableColumn fx:id="colDisciplinaNome" text="Nome" prefWidth="280"/>
+                            <TableColumn fx:id="colDisciplinaCodigo" text="Código" prefWidth="130"/>
+                            <TableColumn fx:id="colDisciplinaSemestre" text="Semestre" prefWidth="130"/>
+                        </columns>
+                    </TableView>
+                    <Text fx:id="msgDisciplinas" fill="GRAY" visible="false"/>
+                </VBox>
+            </Tab>
+
+            <!-- ABA 2: Validação de Atendimentos -->
+            <Tab text="Validação de Atendimentos">
+                <VBox spacing="10" style="-fx-padding: 15;">
+                    <Label text="Atendimentos para Aprovar (RN02/RN09)"
+                           style="-fx-font-size: 15px; -fx-font-weight: bold;"/>
+                    <TableView fx:id="tabelaParaValidar" prefHeight="350" VBox.vgrow="ALWAYS">
+                        <columns>
+                            <TableColumn fx:id="colAluno" text="Aluno" prefWidth="200"/>
+                            <TableColumn fx:id="colAssunto" text="Assunto" prefWidth="300"/>
+                            <TableColumn fx:id="colStatus" text="Status" prefWidth="150"/>
+                        </columns>
+                    </TableView>
+                    <Button text="Validar Atendimento Selecionado" onAction="#handleValidar"
+                            style="-fx-background-color: #6C3483; -fx-text-fill: white; -fx-font-size: 14px; -fx-background-radius: 5;"/>
+                    <Text fx:id="errorMessage" fill="RED" visible="false"/>
+                    <Text fx:id="successMessage" fill="GREEN" visible="false"/>
+                </VBox>
+            </Tab>
+
+        </TabPane>
     </center>
 </BorderPane>


### PR DESCRIPTION
## O que foi feito
Implementação completa da issue #6  — vínculo entre professores e disciplinas, com gestão pelo admin e visualização no dashboard do professor.

## Mudanças
- **Repository:** novo `ProfessorDisciplinaRepository` com métodos `vincular`, `desvincular`, `listarPorProfessor` e `estaVinculado`
- **Service:** novo `ProfessorDisciplinaService` com validações de negócio
- **Admin:** seção de vínculo adicionada na aba "Usuários" do dashboard
- **Professor:** dashboard reestruturado com abas — "Minhas Disciplinas" e "Validação de Atendimentos"

## Funcionalidades
- [x] Admin vincula professor a uma disciplina
- [x] Admin desvincula professor de uma disciplina
- [x] Ao selecionar um professor na tabela, suas disciplinas carregam automaticamente
- [x] Validação que impede vincular a mesma disciplina duas vezes
- [x] Professor visualiza apenas as disciplinas vinculadas a ele no dashboard
- [x] Mensagem orientativa quando professor não tem disciplinas vinculadas

## Como testar
1. Faça login como administrador
2. Acesse a aba **Usuários**, selecione um professor
3. Escolha uma disciplina no combo e clique em **Vincular**
4. Faça login como professor e verifique a aba **Minhas Disciplinas**

Closes #6 